### PR TITLE
max-height workaround for large HTML mails

### DIFF
--- a/website_support/static/src/css/kanban.css
+++ b/website_support/static/src/css/kanban.css
@@ -1,0 +1,9 @@
+.o_kanban_view.o_kanban_grouped .o_kanban_record {
+  overflow: hidden;
+  max-height: 250px;
+  transition: max-height 1s;
+}
+
+.o_kanban_view.o_kanban_grouped .o_kanban_record:hover {
+  max-height: 1000px;
+}

--- a/website_support/views/website_support_ticket_views.xml
+++ b/website_support/views/website_support_ticket_views.xml
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <template id="assets_backend" name="helpdesk assets" inherit_id="web.assets_backend">
+        <xpath expr="." position="inside">
+            <link rel="stylesheet" href="/website_support/static/src/css/kanban.css"/>
+        </xpath>
+    </template>
+
     <record id="website_support_ticket_view_form" model="ir.ui.view">
         <field name="name">website.support.ticket form view</field>
         <field name="model">website.support.ticket</field>


### PR DESCRIPTION
When mails contain large HTML, the Kanban view can be broken because the boxes height is too large. This is a workaround. Better fixes like a mouse roll-over scroll may be done...
So I don't exppect you to merge this, I rather simply provide a workaround.